### PR TITLE
Debug frontend and database errors

### DIFF
--- a/accounts/decorators.py
+++ b/accounts/decorators.py
@@ -4,10 +4,10 @@ from django.contrib import messages
 
 
 class AdminRequiredMixin(LoginRequiredMixin):
-    def dispatch(self, request, *args, **kwargs):
-        if not request.user.is_superuser:
-            messages.error(
-                request, "You are not authorized to access this page."
-            )
-            return redirect("core:home")
-        return super().dispatch(request, *args, **kwargs)
+	def dispatch(self, request, *args, **kwargs):
+		if not request.user.is_superuser:
+			messages.error(
+				request, "You are not authorized to access this page."
+			)
+			return redirect("core:index")
+		return super().dispatch(request, *args, **kwargs)

--- a/core/urls.py
+++ b/core/urls.py
@@ -14,6 +14,7 @@ app_name = 'core'
 urlpatterns = [
     # Public pages
     path('', views.IndexView.as_view(), name='index'),
+    path('home/', views.IndexView.as_view(), name='home'),
     path('about/', TemplateView.as_view(template_name='core/about.html'), name='about'),
     path('contact/', TemplateView.as_view(template_name='core/contact.html'), name='contact'),
     path('services/', TemplateView.as_view(template_name='core/services.html'), name='services'),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,7 +49,7 @@ services:
       - DEBUG=False
       - SECRET_KEY=${SECRET_KEY:?SECRET_KEY is required}
       - ALLOWED_HOSTS=${ALLOWED_HOSTS:-65.108.91.110,localhost,127.0.0.1}
-      - CSRF_TRUSTED_ORIGINS=${CSRF_TRUSTED_ORIGINS:-http://65.108.91.110:8080,https://65.108.91.110:8080}
+      - CSRF_TRUSTED_ORIGINS=${CSRF_TRUSTED_ORIGINS:-http://65.108.91.110,https://65.108.91.110}
       - CSRF_COOKIE_SECURE=False
       - SESSION_COOKIE_SECURE=False
       
@@ -78,13 +78,13 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE: http://65.108.91.110:3000
+        VITE_API_BASE: http://65.108.91.110
         NODE_ENV: production
     expose:
       - 3000
     environment:
       - NODE_ENV=production
-      - VITE_API_BASE=http://65.108.91.110:3000
+      - VITE_API_BASE=http://65.108.91.110
     depends_on:
       web:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: laso_django
+    user: root
     ports:
       - "8005:8005"
     volumes:
@@ -47,7 +48,7 @@ services:
         VITE_API_BASE: http://localhost:8005
     container_name: laso_react
     ports:
-      - "3000:3000"
+      - "3000:80"
     environment:
       - VITE_API_BASE=http://localhost:8005
     depends_on:

--- a/templates/bookings/booking.html
+++ b/templates/bookings/booking.html
@@ -13,7 +13,7 @@
                 <div class="col-md-12 col-12">
                     <nav aria-label="breadcrumb" class="page-breadcrumb">
                         <ol class="breadcrumb">
-                            <li class="breadcrumb-item"><a href="{% url 'core:home' %}">Home</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'core:index' %}">Home</a></li>
                             <li class="breadcrumb-item active" aria-current="page">Booking</li>
                         </ol>
                     </nav>

--- a/templates/doctors/list.html
+++ b/templates/doctors/list.html
@@ -15,7 +15,7 @@
                 <div class="col-md-8 col-12">
                     <nav aria-label="breadcrumb">
                         <ol class="breadcrumb mb-0 bg-transparent">
-                            <li class="breadcrumb-item"><a href="{% url 'core:home' %}" class="text-decoration-none">Home</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'core:index' %}" class="text-decoration-none">Home</a></li>
                             <li class="breadcrumb-item active" aria-current="page">Doctors</li>
                         </ol>
                     </nav>

--- a/templates/doctors/profile.html
+++ b/templates/doctors/profile.html
@@ -16,7 +16,7 @@
                 <div class="col-md-12 col-12">
                     <nav aria-label="breadcrumb" class="page-breadcrumb">
                         <ol class="breadcrumb">
-                            <li class="breadcrumb-item"><a href="{% url 'core:home' %}">Home</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'core:index' %}">Home</a></li>
                             <li class="breadcrumb-item active" aria-current="page">Doctor Profile</li>
                         </ol>
                     </nav>

--- a/templates/includes/doctor-sidebar.html
+++ b/templates/includes/doctor-sidebar.html
@@ -22,7 +22,7 @@
                 <div class="col-md-12 col-12">
                     <nav aria-label="breadcrumb" class="page-breadcrumb">
                         <ol class="breadcrumb">
-                            <li class="breadcrumb-item"><a href="{% url 'core:home' %}">Home</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'core:index' %}">Home</a></li>
                             <li class="breadcrumb-item active" aria-current="page">{% block page_name1 %}{% endblock %}</li>
                         </ol>
                     </nav>

--- a/templates/includes/patient-base.html
+++ b/templates/includes/patient-base.html
@@ -14,7 +14,7 @@
             <div class="col-md-12 col-12">
                 <nav aria-label="breadcrumb" class="page-breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">Home</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">Home</a></li>
                         <li class="breadcrumb-item active" aria-current="page">{% block page_name2 %}{% endblock %}</li>
                     </ol>
                 </nav>

--- a/vitals/templates/vitals/add_patient_goal.html
+++ b/vitals/templates/vitals/add_patient_goal.html
@@ -11,7 +11,7 @@
             <div class="col-md-12 col-12">
                 <nav aria-label="breadcrumb" class="page-breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">{% trans "Home" %}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">{% trans "Home" %}</a></li>
                         {% if request.user.role == 'doctor' %}
                         <li class="breadcrumb-item"><a href="{% url 'doctors:my-patients' %}">{% trans "My Patients" %}</a></li>
                         {% else %}

--- a/vitals/templates/vitals/add_patient_vital.html
+++ b/vitals/templates/vitals/add_patient_vital.html
@@ -11,7 +11,7 @@
             <div class="col-md-12 col-12">
                 <nav aria-label="breadcrumb" class="page-breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">{% trans "Home" %}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">{% trans "Home" %}</a></li>
                         {% if request.user.role == 'doctor' %}
                         <li class="breadcrumb-item"><a href="{% url 'doctors:my-patients' %}">{% trans "My Patients" %}</a></li>
                         {% else %}

--- a/vitals/templates/vitals/add_vital_record.html
+++ b/vitals/templates/vitals/add_vital_record.html
@@ -11,7 +11,7 @@
             <div class="col-md-12 col-12">
                 <nav aria-label="breadcrumb" class="page-breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">{% trans "Home" %}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">{% trans "Home" %}</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'vitals:patient-dashboard' %}">{% trans "Vitals Dashboard" %}</a></li>
                         <li class="breadcrumb-item active" aria-current="page">{% trans "Record Vital Sign" %}</li>
                     </ol>

--- a/vitals/templates/vitals/manage_goals.html
+++ b/vitals/templates/vitals/manage_goals.html
@@ -11,7 +11,7 @@
             <div class="col-md-12 col-12">
                 <nav aria-label="breadcrumb" class="page-breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">{% trans "Home" %}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">{% trans "Home" %}</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'vitals:patient-dashboard' %}">{% trans "Vitals Dashboard" %}</a></li>
                         <li class="breadcrumb-item active" aria-current="page">{% trans "Manage Goals" %}</li>
                     </ol>

--- a/vitals/templates/vitals/patient_dashboard.html
+++ b/vitals/templates/vitals/patient_dashboard.html
@@ -12,7 +12,7 @@
             <div class="col-md-12 col-12">
                 <nav aria-label="breadcrumb" class="page-breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">{% trans "Home" %}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">{% trans "Home" %}</a></li>
                         <li class="breadcrumb-item active" aria-current="page">{% trans "Vitals Dashboard" %}</li>
                     </ol>
                 </nav>

--- a/vitals/templates/vitals/patient_vitals.html
+++ b/vitals/templates/vitals/patient_vitals.html
@@ -383,7 +383,7 @@
             <div class="col-md-12">
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">{% trans "Home" %}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">{% trans "Home" %}</a></li>
                         {% if request.user.role == 'doctor' %}
                         <li class="breadcrumb-item"><a href="{% url 'doctors:my-patients' %}">{% trans "My Patients" %}</a></li>
                         {% else %}

--- a/vitals/templates/vitals/vital_history.html
+++ b/vitals/templates/vitals/vital_history.html
@@ -71,7 +71,7 @@
             <div class="col-md-12 col-12">
                 <nav aria-label="breadcrumb" class="page-breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">{% trans "Home" %}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">{% trans "Home" %}</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'vitals:patient-dashboard' %}">{% trans "Vitals Dashboard" %}</a></li>
                         <li class="breadcrumb-item active" aria-current="page">{% trans "History" %}</li>
                     </ol>

--- a/vitals/templates/vitals/vitals_analytics.html
+++ b/vitals/templates/vitals/vitals_analytics.html
@@ -268,7 +268,7 @@
             <div class="col-md-12">
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{% url 'core:home' %}">{% trans "Home" %}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'core:index' %}">{% trans "Home" %}</a></li>
                         {% if patient %}
                             {% if request.user.role == 'doctor' %}
                             <li class="breadcrumb-item"><a href="{% url 'doctors:my-patients' %}">{% trans "My Patients" %}</a></li>

--- a/vitals/views.py
+++ b/vitals/views.py
@@ -25,7 +25,7 @@ def patient_vitals_dashboard(request):
     # Only patients can access this view
     if request.user.role != 'patient':
         messages.error(request, _("Only patients can access this page."))
-        return redirect('core:home')
+        return redirect('core:index')
     
     # Get latest vital records for each category
     categories = VitalCategory.objects.filter(is_active=True)
@@ -97,7 +97,7 @@ def add_vital_record(request):
                     return redirect('admin-patients')
                 except User.DoesNotExist:
                     messages.error(request, _("Patient not found."))
-                    return redirect('core:home')
+                    return redirect('core:index')
             
             # For patients adding their own vitals
             messages.success(request, _("Vital sign recorded successfully."))


### PR DESCRIPTION
Fixes frontend not showing, Django `NoReverseMatch` for 'home', and SQLite read-only errors.

The frontend was not accessible due to incorrect port mapping (`3000:3000` changed to `3000:80`). `NoReverseMatch` for 'home' was resolved by updating references to `core:index` and adding a `core:home` alias. The SQLite "read-only database" error in development is fixed by running the Django service as root to mitigate bind-mount permission issues. Production environment variables for `VITE_API_BASE` and `CSRF_TRUSTED_ORIGINS` were also corrected for proper API routing via Nginx.

---
<a href="https://cursor.com/background-agent?bcId=bc-07dba17a-d150-404a-8dbd-54f01a24bdd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07dba17a-d150-404a-8dbd-54f01a24bdd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

