### PR TITLE
Fix log file permission error for deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     volumes:
       - static_volume:/app/staticfiles
       - media_volume:/app/media
-      - ./logs:/app/logs
+      - logs_volume:/app/logs
     ports:
       - "8000:8000"
     depends_on:
@@ -100,7 +100,7 @@ services:
       - HUGGINGFACE_API_KEY=${HUGGINGFACE_API_KEY}
     volumes:
       - media_volume:/app/media
-      - ./logs:/app/logs
+      - logs_volume:/app/logs
     depends_on:
       - db
       - redis
@@ -123,7 +123,7 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-laso_user}:${POSTGRES_PASSWORD:-laso_password}@db:5432/${POSTGRES_DB:-laso_healthcare}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-redis_password}@redis:6379/0
     volumes:
-      - ./logs:/app/logs
+      - logs_volume:/app/logs
     depends_on:
       - db
       - redis
@@ -183,6 +183,8 @@ volumes:
   static_volume:
     driver: local
   media_volume:
+    driver: local
+  logs_volume:
     driver: local
 
 networks:

--- a/meditrack/settings.py
+++ b/meditrack/settings.py
@@ -319,34 +319,32 @@ if REDIS_URL:
     CELERY_TIMEZONE = TIME_ZONE
     CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
 
+LOG_TO_FILE = config('LOG_TO_FILE', default=False, cast=bool)
+
 # Logging Settings
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'handlers': {
-        'file': {
-            'level': 'INFO',
-            'class': 'logging.FileHandler',
-            'filename': BASE_DIR / 'meditrack.log',
-        },
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
         },
+        # 'file' handler is added below only if enabled
     },
     'loggers': {
         'django': {
-            'handlers': ['file', 'console'],
+            'handlers': ['console'],
             'level': 'INFO',
             'propagate': True,
         },
         'telemedicine': {
-            'handlers': ['file', 'console'],
+            'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': True,
         },
         'core.ai_features': {
-            'handlers': ['file', 'console'],
+            'handlers': ['console'],
             'level': 'INFO',
             'propagate': True,
         },
@@ -363,8 +361,16 @@ if not DEBUG:
     # Performance settings
     CONN_MAX_AGE = config('DB_CONN_MAX_AGE', default=300, cast=int)
     
-    # Logging to files in production
-    LOGGING['handlers']['file']['filename'] = '/app/logs/django.log'
+    # Optional: log to file in production only if explicitly enabled
+    if LOG_TO_FILE:
+        LOGGING['handlers']['file'] = {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': '/app/logs/django.log',
+        }
+        LOGGING['loggers']['django']['handlers'] = ['console', 'file']
+        LOGGING['loggers']['telemedicine']['handlers'] = ['console', 'file']
+        LOGGING['loggers']['core.ai_features']['handlers'] = ['console', 'file']
     SECURE_HSTS_SECONDS = 31536000
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True


### PR DESCRIPTION
Use a named Docker volume for logs and default Django production logging to console to fix `PermissionError` during deployment.

The `web` service failed to boot due to a `PermissionError` when trying to write to `/app/logs/django.log`. This was caused by the container's non-root user lacking write permissions to the host-mounted log directory. Switching to a named volume ensures the container has proper write access, and making file logging optional via `LOG_TO_FILE` prevents similar issues by defaulting to console output.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf39620e-9ed9-4122-8545-2f7a7216c9f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf39620e-9ed9-4122-8545-2f7a7216c9f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

