### PR TITLE
Set default locale to english and fix url errors

### DIFF
--- a/Templates/core/doctor_list.html
+++ b/Templates/core/doctor_list.html
@@ -1,25 +1,25 @@
 {% extends 'core/base.html' %}
 {% load static %}
 
-{% block title %}Doktorlar{% endblock %}
+{% block title %}Doctors{% endblock %}
 
 {% block content %}
 <div class="container py-4">
     <div class="row mb-4">
         <div class="col">
-            <h1 class="h3 mb-0">Doktorlar</h1>
-            <p class="text-muted">Tüm doktorların listesi</p>
+            <h1 class="h3 mb-0">Doctors</h1>
+            <p class="text-muted">List of all doctors</p>
         </div>
         <div class="col-auto">
             <div class="d-flex">
                 <form method="get" class="d-flex me-2">
-                    <input type="text" name="search" class="form-control me-2" placeholder="Doktor ara..." value="{{ request.GET.search }}">
-                    <button type="submit" class="btn btn-primary">Ara</button>
+                    <input type="text" name="search" class="form-control me-2" placeholder="Search doctors..." value="{{ request.GET.search }}">
+                    <button type="submit" class="btn btn-primary">Search</button>
                 </form>
                 
                 {% if user.is_admin_user or user.is_superuser %}
                 <a href="{% url 'doctor-create' %}" class="btn btn-success">
-                    <i class="fas fa-plus"></i> Doktor Ekle
+                    <i class="fas fa-plus"></i> Add Doctor
                 </a>
                 {% endif %}
             </div>
@@ -29,7 +29,7 @@
     {% if available_doctors and user.is_patient %}
     <div class="card shadow mb-4 border-success">
         <div class="card-header bg-success text-white">
-            <h5 class="mb-0">📊 Şu Anda Müsait Doktorlar ({{ current_time|date:"H:i" }})</h5>
+            <h5 class="mb-0">📊 Currently Available Doctors ({{ current_time|date:"H:i" }})</h5>
         </div>
         <div class="card-body">
             <div class="row">
@@ -38,13 +38,13 @@
                     <div class="card h-100 border-success">
                         <div class="card-body">
                             <h5 class="card-title">{{ doctor.get_full_name }}</h5>
-                            <h6 class="card-subtitle mb-2 text-muted">{{ doctor.specialization|default:"Genel Doktor" }}</h6>
+                            <h6 class="card-subtitle mb-2 text-muted">{{ doctor.specialization|default:"General Practitioner" }}</h6>
                             <div class="mt-3">
-                                <a href="{% url 'appointment-create' %}?doctor={{ doctor.id }}" class="btn btn-sm btn-success">
-                                    <i class="fas fa-calendar-plus"></i> Hemen Randevu Al
+                                <a href="{% url 'core:appointment-create' %}?doctor={{ doctor.id }}" class="btn btn-sm btn-success">
+                                    <i class="fas fa-calendar-plus"></i> Book Appointment
                                 </a>
                                 <a href="{% url 'doctor-calendar' doctor.id %}" class="btn btn-sm btn-outline-success ms-1">
-                                    <i class="fas fa-calendar"></i> Takvim
+                                    <i class="fas fa-calendar"></i> Calendar
                                 </a>
                             </div>
                         </div>
@@ -53,7 +53,7 @@
                 {% empty %}
                 <div class="col-12">
                     <div class="alert alert-info mb-0">
-                        Şu anda müsait doktor bulunmamaktadır. Lütfen diğer doktorların takvimlerini kontrol ediniz.
+                        No doctors are currently available. Please check other doctors' calendars.
                     </div>
                 </div>
                 {% endfor %}
@@ -68,11 +68,11 @@
                 <table class="table table-hover">
                     <thead>
                         <tr>
-                            <th>Ad Soyad</th>
-                            <th>Uzmanlık</th>
-                            <th>E-posta</th>
-                            <th>Telefon</th>
-                            <th>İşlemler</th>
+                            <th>Full Name</th>
+                            <th>Specialization</th>
+                            <th>Email</th>
+                            <th>Phone</th>
+                            <th>Actions</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -85,26 +85,26 @@
                                     <td>{{ doctor.phone|default:"-" }}</td>
                                     <td>
                                         {% if user.is_patient or user.is_receptionist %}
-                                            <a href="{% url 'appointment-create' %}?doctor={{ doctor.id }}" class="btn btn-sm btn-primary">
-                                                <i class="fas fa-calendar-plus"></i> Randevu Al
+                                            <a href="{% url 'core:appointment-create' %}?doctor={{ doctor.id }}" class="btn btn-sm btn-primary">
+                                                <i class="fas fa-calendar-plus"></i> Book Appointment
                                             </a>
                                         {% endif %}
                                         
-                                        <a href="{% url 'doctor-calendar' doctor.id %}" class="btn btn-sm btn-info">
-                                            <i class="ki-outline ki-calendar fs-2"></i> Takvim
-                                        </a>
+                                                                <a href="{% url 'doctor-calendar' doctor.id %}" class="btn btn-sm btn-info">
+                            <i class="ki-outline ki-calendar fs-2"></i> Calendar
+                        </a>
                                         
                                         {% if user.is_admin_user or user.is_superuser %}
-                                            <a href="{% url 'doctor-update' doctor.id %}" class="btn btn-sm btn-warning">
-                                                <i class="fas fa-edit"></i> Düzenle
-                                            </a>
+                                                                        <a href="{% url 'doctor-update' doctor.id %}" class="btn btn-sm btn-warning">
+                                <i class="fas fa-edit"></i> Edit
+                            </a>
                                         {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}
                         {% else %}
                             <tr>
-                                <td colspan="5" class="text-center">Doktor bulunamadı.</td>
+                                <td colspan="5" class="text-center">No doctors found.</td>
                             </tr>
                         {% endif %}
                     </tbody>

--- a/Templates/telemedicine/schedule_consultation.html
+++ b/Templates/telemedicine/schedule_consultation.html
@@ -1,0 +1,93 @@
+{% extends 'core/base.html' %}
+{% load static %}
+
+{% block title %}Schedule Telemedicine Consultation{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card shadow">
+                <div class="card-header bg-primary text-white">
+                    <h4 class="mb-0">
+                        <i class="fas fa-video"></i> Schedule Telemedicine Consultation
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <form method="post">
+                        {% csrf_token %}
+                        
+                        <div class="mb-3">
+                            <label for="{{ form.appointment.id_for_label }}" class="form-label">
+                                Select Appointment
+                            </label>
+                            {{ form.appointment }}
+                            {% if form.appointment.errors %}
+                                <div class="invalid-feedback d-block">
+                                    {{ form.appointment.errors.0 }}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="{{ form.consultation_type.id_for_label }}" class="form-label">
+                                Consultation Type
+                            </label>
+                            {{ form.consultation_type }}
+                            {% if form.consultation_type.errors %}
+                                <div class="invalid-feedback d-block">
+                                    {{ form.consultation_type.errors.0 }}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="{{ form.platform.id_for_label }}" class="form-label">
+                                Platform
+                            </label>
+                            {{ form.platform }}
+                            {% if form.platform.errors %}
+                                <div class="invalid-feedback d-block">
+                                    {{ form.platform.errors.0 }}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="{{ form.notes.id_for_label }}" class="form-label">
+                                Notes (Optional)
+                            </label>
+                            {{ form.notes }}
+                            {% if form.notes.errors %}
+                                <div class="invalid-feedback d-block">
+                                    {{ form.notes.errors.0 }}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="d-flex justify-content-between">
+                            <a href="{% url 'telemedicine:list' %}" class="btn btn-secondary">
+                                <i class="fas fa-arrow-left"></i> Back to List
+                            </a>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-calendar-plus"></i> Schedule Consultation
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+.form-control, .form-select {
+    border: 1px solid #12bab8;
+}
+
+.form-control:focus, .form-select:focus {
+    border-color: #0ea5a3;
+    box-shadow: 0 0 0 0.2rem rgba(18, 186, 184, 0.25);
+}
+</style>
+{% endblock %}

--- a/check_fixes.py
+++ b/check_fixes.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Simple script to verify the fixes made to the codebase
+"""
+import os
+import re
+
+def check_template_urls():
+    """Check for fixed URLs in templates"""
+    issues_found = []
+    
+    # Check doctor_list.html for appointment-create fixes
+    doctor_list_path = "/workspace/Templates/core/doctor_list.html"
+    if os.path.exists(doctor_list_path):
+        with open(doctor_list_path, 'r') as f:
+            content = f.read()
+            
+        # Check for namespaced appointment-create URLs
+        if 'core:appointment-create' in content:
+            print("✓ Fixed: doctor_list.html uses namespaced appointment-create URL")
+        else:
+            issues_found.append("doctor_list.html still has unnamespaced appointment-create URLs")
+        
+        # Check for English text
+        turkish_patterns = ['Doktor', 'Randevu', 'Hastalar', 'Doktorlar']
+        for pattern in turkish_patterns:
+            if pattern in content:
+                issues_found.append(f"doctor_list.html still contains Turkish text: {pattern}")
+    
+    # Check telemedicine URLs
+    telemedicine_urls_path = "/workspace/telemedicine/urls.py"
+    if os.path.exists(telemedicine_urls_path):
+        with open(telemedicine_urls_path, 'r') as f:
+            content = f.read()
+            
+        if "name='schedule'" in content:
+            print("✓ Fixed: telemedicine URLs include schedule pattern")
+        else:
+            issues_found.append("telemedicine urls.py missing schedule URL pattern")
+    
+    # Check telemedicine views for CreateView
+    telemedicine_views_path = "/workspace/telemedicine/views.py"
+    if os.path.exists(telemedicine_views_path):
+        with open(telemedicine_views_path, 'r') as f:
+            content = f.read()
+            
+        if "TeleMedicineConsultationCreateView" in content:
+            print("✓ Fixed: telemedicine views include CreateView")
+        else:
+            issues_found.append("telemedicine views.py missing TeleMedicineConsultationCreateView")
+    
+    return issues_found
+
+def main():
+    print("Checking fixes...")
+    issues = check_template_urls()
+    
+    if issues:
+        print("\nIssues found:")
+        for issue in issues:
+            print(f"  ❌ {issue}")
+    else:
+        print("\n✅ All fixes appear to be in place!")
+
+if __name__ == "__main__":
+    main()

--- a/telemedicine/urls.py
+++ b/telemedicine/urls.py
@@ -6,6 +6,7 @@ app_name = 'telemedicine'
 urlpatterns = [
     # Main views
     path('', views.TeleMedicineConsultationListView.as_view(), name='list'),
+    path('schedule/', views.TeleMedicineConsultationCreateView.as_view(), name='schedule'),
     path('session/<str:meeting_id>/', views.TeleMedicineConsultationDetailView.as_view(), name='detail'),
     path('settings/', views.TeleMedicineSettingsView.as_view(), name='settings'),
 ]


### PR DESCRIPTION
Fix `NoReverseMatch` errors for appointment and telemedicine scheduling, and translate the doctor list UI to English.

The `NoReverseMatch` errors were caused by an un-namespaced `appointment-create` URL reference in `doctor_list.html` and a completely missing `schedule` URL pattern and view in the telemedicine application. This PR resolves these by adding the missing telemedicine components and correcting the `appointment-create` URL. Additionally, the `doctor_list.html` template has been translated from Turkish to English, and a new telemedicine scheduling template includes teal styling for form elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5a8cb62-f969-4fd2-a43d-bf20ae45e414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5a8cb62-f969-4fd2-a43d-bf20ae45e414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

