### PR TITLE
Fix django 500 errors and ui issues

### DIFF
--- a/Templates/core/patient_dashboard.html
+++ b/Templates/core/patient_dashboard.html
@@ -201,7 +201,7 @@
                                                 </span>
                                             </td>
                                             <td class="text-end">
-                                                <a href="{% url 'appointment-detail' appointment.id %}" class="btn btn-icon btn-bg-light btn-active-color-primary btn-sm me-1" title="View Details">
+                                                <a href="{% url 'core:appointment-detail' appointment.id %}" class="btn btn-icon btn-bg-light btn-active-color-primary btn-sm me-1" title="View Details">
                                                     <i class="ki-outline ki-eye fs-2"></i>
                                                 </a>
                                             </td>

--- a/Templates/core/patient_detail.html
+++ b/Templates/core/patient_detail.html
@@ -119,7 +119,7 @@
                                                 {% endif %}
                                             </td>
                                             <td>
-                                                <a href="{% url 'appointment-detail' appointment.id %}" class="btn btn-sm btn-info">
+                                                <a href="{% url 'core:appointment-detail' appointment.id %}" class="btn btn-sm btn-info">
                                                     <i class="fas fa-eye"></i> Görüntüle
                                                 </a>
                                             </td>

--- a/Templates/core/treatment_detail.html
+++ b/Templates/core/treatment_detail.html
@@ -186,7 +186,7 @@
                 </div>
                 <div class="card-body">
                     <div class="d-grid gap-2">
-                        <a href="{% url 'appointment-detail' treatment.appointment.id %}" class="btn btn-primary">
+                        <a href="{% url 'core:appointment-detail' treatment.appointment.id %}" class="btn btn-primary">
                             <i class="ki-outline ki-calendar fs-2"></i> Randevu Detayı
                         </a>
                         

--- a/meditrack/settings.py
+++ b/meditrack/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = config('SECRET_KEY', default='django-insecure-$87@n^(g6isfhz4rt7uxv
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DEBUG', default=True, cast=bool)
 
-ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='localhost,127.0.0.1,65.108.91.110,*', cast=Csv())
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='localhost,127.0.0.1,65.108.91.110,host.docker.internal,*', cast=Csv())
 
 
 # Application definition

--- a/telemedicine/migrations/0003_add_notes_field.py
+++ b/telemedicine/migrations/0003_add_notes_field.py
@@ -1,0 +1,22 @@
+# Generated manually to add notes field for backward compatibility
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('telemedicine', '0002_alter_telemeddocument_options_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='telemedicineconsultation',
+            name='notes',
+            field=models.TextField(
+                blank=True,
+                verbose_name='Notes',
+                help_text='General notes about the consultation'
+            ),
+        ),
+    ]

--- a/telemedicine/models.py
+++ b/telemedicine/models.py
@@ -499,6 +499,13 @@ class TeleMedicineConsultation(models.Model):
         verbose_name=_('Consultation Notes')
     )
     
+    # Backward compatibility field
+    notes = models.TextField(
+        blank=True,
+        verbose_name=_('Notes'),
+        help_text=_('General notes about the consultation')
+    )
+    
     patient_feedback = models.TextField(
         blank=True,
         verbose_name=_('Patient Feedback')

--- a/telemedicine/urls.py
+++ b/telemedicine/urls.py
@@ -9,4 +9,13 @@ urlpatterns = [
     path('schedule/', views.TeleMedicineConsultationCreateView.as_view(), name='schedule'),
     path('session/<str:meeting_id>/', views.TeleMedicineConsultationDetailView.as_view(), name='detail'),
     path('settings/', views.TeleMedicineSettingsView.as_view(), name='settings'),
+    
+    # Telemedicine Appointments
+    path('appointments/', views.TelemedicineAppointmentListView.as_view(), name='appointment-list'),
+    path('appointments/create/', views.create_telemedicine_appointment, name='appointment-create'),
+    path('appointments/<int:pk>/', views.TelemedicineAppointmentDetailView.as_view(), name='appointment-detail'),
+    
+    # Video Session Management
+    path('session/<int:appointment_id>/start/', views.start_video_session, name='start-session'),
+    path('session/<int:session_id>/end/', views.end_video_session, name='end-session'),
 ]

--- a/telemedicine/views.py
+++ b/telemedicine/views.py
@@ -560,7 +560,7 @@ def create_telemedicine_appointment(request):
                 )
             
             messages.success(request, "Telemedicine appointment created successfully.")
-            return redirect('telemedicine-appointment-detail', pk=appointment.pk)
+            return redirect('telemedicine:appointment-detail', pk=appointment.pk)
     else:
         form = TelemedicineAppointmentForm(user=request.user)
         
@@ -574,7 +574,7 @@ def start_video_session(request, appointment_id):
     # Yetki kontrolü
     if not (request.user == appointment.doctor or request.user == appointment.patient):
         messages.error(request, "You do not have permission to access this session.")
-        return redirect('telemedicine-appointment-list')
+        return redirect('telemedicine:appointment-list')
     
     # Appointment time check
     now = timezone.now()
@@ -584,11 +584,11 @@ def start_video_session(request, appointment_id):
     # Allow access 10 minutes before or 30 minutes after appointment
     if time_diff > 10:
         messages.warning(request, f"The session has not started yet. Your appointment is at {appointment.time.strftime('%H:%M')}.")
-        return redirect('telemedicine-appointment-detail', pk=appointment_id)
+        return redirect('telemedicine:appointment-detail', pk=appointment_id)
     
     if time_diff < -30:
         messages.warning(request, "This appointment has expired. Please create a new appointment.")
-        return redirect('telemedicine-appointment-list')
+        return redirect('telemedicine:appointment-list')
     
     # Aktif görüşme var mı kontrol et
     active_session = VideoSession.objects.filter(


### PR DESCRIPTION
Fix multiple 500 errors and broken UI by resolving `NoReverseMatch` for appointment URLs, adding a missing `notes` field to `TeleMedicineConsultation`, and allowing `host.docker.internal` in `ALLOWED_HOSTS`.

This PR addresses the following issues:
*   `NoReverseMatch: Reverse for 'appointment-detail' not found`: Fixed by adding the `core:` namespace to `appointment-detail` URLs in templates and defining missing `telemedicine:appointment-detail` and related URL patterns in `telemedicine/urls.py`, along with updating redirects in `telemedicine/views.py`.
*   `FieldError: Unknown field(s) (notes) specified for TeleMedicineConsultation`: Fixed by adding a `notes` field to the `TeleMedicineConsultation` model for backward compatibility and creating a manual migration.
*   `Invalid HTTP_HOST header: 'host.docker.internal:8000'`: Fixed by adding `host.docker.internal` to `ALLOWED_HOSTS` in `settings.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5085519-d267-4ee3-9da5-0d1293b524cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5085519-d267-4ee3-9da5-0d1293b524cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

